### PR TITLE
Update Alibaba Cloud SDK link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ AliDNS for [`libdns`](https://github.com/libdns/libdns)
 =======================
 [![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/alidns)
 
-This package implements the [libdns interfaces](https://github.com/libdns/libdns), allowing you to manage DNS records with the [AliDNS API](https://api.aliyun.com/document/Alidns/2015-01-09/overview) ( which has a nice Go SDK implementation [here](https://github.com/aliyun/alibaba-cloud-sdk-go) )
+This package implements the [libdns interfaces](https://github.com/libdns/libdns), allowing you to manage DNS records with the [AliDNS API](https://api.aliyun.com/document/Alidns/2015-01-09/overview) ( which has a nice Go SDK implementation [here](https://github.com/aliyun/alibabacloud-go-sdk) )
 
 ## Authenticating
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ AliDNS for [`libdns`](https://github.com/libdns/libdns)
 =======================
 [![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/alidns)
 
-This package implements the [libdns interfaces](https://github.com/libdns/libdns), allowing you to manage DNS records with the [AliDNS API](https://api.aliyun.com/document/Alidns/2015-01-09/overview) ( which has a nice Go SDK implementation [here](https://github.com/aliyun/alibabacloud-go-sdk) )
+This package implements the [libdns interfaces](https://github.com/libdns/libdns), allowing you to manage DNS records with the [AliDNS API](https://api.aliyun.com/document/Alidns/2015-01-09/overview) ( which has a nice Go SDK implementation [here](https://github.com/aliyun/alibabacloud-go-sdk/tree/7f23fa1a357f6570dddd74103a15edeea5b69d37/alidns-20150109) )
 
 ## Authenticating
 


### PR DESCRIPTION
Update the link pointing to old cloud SDK repo since it has been archived as V1 SDK entered its end-of-support